### PR TITLE
Adding the hashbang to execute with the node in the environment

### DIFF
--- a/bin/start.mjs
+++ b/bin/start.mjs
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import $ from 'tinyspawn'
 import send from 'anybar'
 


### PR DESCRIPTION
Adding the hashbang to execute with the node in the environment

To avoid errors with the imports while using node' dependant environment (such as with the `nvm`).
<img width="1081" alt="image" src="https://github.com/Kikobeats/anybar-ping/assets/701909/f1c28130-37f6-4470-b428-29ce37497430">
